### PR TITLE
Make TemporaryFiles private members public

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/IO/issues/84
+Your prepared branch: issue-84-05054668
+Your prepared working directory: /tmp/gh-issue-solver-1757705722798
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/IO/issues/84
-Your prepared branch: issue-84-05054668
-Your prepared working directory: /tmp/gh-issue-solver-1757705722798
-
-Proceed.

--- a/csharp/Platform.IO/TemporaryFiles.cs
+++ b/csharp/Platform.IO/TemporaryFiles.cs
@@ -10,11 +10,34 @@ namespace Platform.IO
     /// </summary>
     public class TemporaryFiles
     {
-        private const string UserFilesListFileNamePrefix = ".used-temporary-files.txt";
-        private static readonly object UsedFilesListLock = new();
-        private static readonly string UsedFilesListFilename = Assembly.GetExecutingAssembly().Location + UserFilesListFileNamePrefix;
+        /// <summary>
+        /// <para>The prefix used for the temporary files list filename.</para>
+        /// <para>Префикс, используемый для имени файла списка временных файлов.</para>
+        /// </summary>
+        public const string UserFilesListFileNamePrefix = ".used-temporary-files.txt";
+        
+        /// <summary>
+        /// <para>The lock object used to synchronize access to the used files list.</para>
+        /// <para>Объект блокировки, используемый для синхронизации доступа к списку используемых файлов.</para>
+        /// </summary>
+        public static readonly object UsedFilesListLock = new();
+        
+        /// <summary>
+        /// <para>The filename of the used files list.</para>
+        /// <para>Имя файла списка используемых файлов.</para>
+        /// </summary>
+        public static readonly string UsedFilesListFilename = Assembly.GetExecutingAssembly().Location + UserFilesListFileNamePrefix;
+        
+        /// <summary>
+        /// <para>Adds a filename to the used files list.</para>
+        /// <para>Добавляет имя файла в список используемых файлов.</para>
+        /// </summary>
+        /// <param name="filename">
+        /// <para>The filename to add to the list.</para>
+        /// <para>Имя файла для добавления в список.</para>
+        /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void AddToUsedFilesList(string filename)
+        public static void AddToUsedFilesList(string filename)
         {
             lock (UsedFilesListLock)
             {


### PR DESCRIPTION
## Summary

This PR addresses issue #84 by making the following private members of the `TemporaryFiles` class public:

- `UserFilesListFileNamePrefix` - const string for the temporary files list filename prefix
- `UsedFilesListLock` - static readonly object for synchronizing access to the used files list
- `UsedFilesListFilename` - static readonly string containing the full path to the used files list
- `AddToUsedFilesList(string filename)` - static method to add a filename to the used files list

## Changes Made

- Changed access modifiers from `private` to `public` for all identified members
- Added comprehensive XML documentation following the existing codebase patterns (English + Russian)
- Maintained all existing functionality and behavior
- All existing tests continue to pass

## Test Plan

- [x] Built solution successfully with no errors
- [x] All existing tests pass
- [x] No breaking changes to existing public API
- [x] XML documentation warnings resolved

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #84