### PR TITLE
Rename UsedFilesListLock to UsedFilesListLockObject

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/IO/issues/83
-Your prepared branch: issue-83-f1de69e6
-Your prepared working directory: /tmp/gh-issue-solver-1757705772748
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/IO/issues/83
+Your prepared branch: issue-83-f1de69e6
+Your prepared working directory: /tmp/gh-issue-solver-1757705772748
+
+Proceed.

--- a/csharp/Platform.IO/TemporaryFiles.cs
+++ b/csharp/Platform.IO/TemporaryFiles.cs
@@ -11,12 +11,12 @@ namespace Platform.IO
     public class TemporaryFiles
     {
         private const string UserFilesListFileNamePrefix = ".used-temporary-files.txt";
-        private static readonly object UsedFilesListLock = new();
+        private static readonly object UsedFilesListLockObject = new();
         private static readonly string UsedFilesListFilename = Assembly.GetExecutingAssembly().Location + UserFilesListFileNamePrefix;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void AddToUsedFilesList(string filename)
         {
-            lock (UsedFilesListLock)
+            lock (UsedFilesListLockObject)
             {
                 FileHelpers.AppendLine(UsedFilesListFilename, filename);
             }
@@ -45,7 +45,7 @@ namespace Platform.IO
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void DeleteAllPreviouslyUsed()
         {
-            lock (UsedFilesListLock)
+            lock (UsedFilesListLockObject)
             {
                 var listFilename = UsedFilesListFilename;
                 if (File.Exists(listFilename))


### PR DESCRIPTION
This pull request addresses issue #83 by renaming the lock object variable for better clarity.

## Changes Made
- Renamed the static field `UsedFilesListLock` to `UsedFilesListLockObject` in `TemporaryFiles.cs:14`
- Updated all references to use the new variable name in lock statements

## Testing
- All existing tests pass
- Project builds successfully without errors

Fixes #83

🤖 Generated with [Claude Code](https://claude.ai/code)