### PR TITLE
Rename DeleteAll method to DeleteFiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/IO/issues/53
-Your prepared branch: issue-53-2cc54528
-Your prepared working directory: /tmp/gh-issue-solver-1757775656448
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/IO/issues/53
+Your prepared branch: issue-53-2cc54528
+Your prepared working directory: /tmp/gh-issue-solver-1757775656448
+
+Proceed.

--- a/cpp/Platform.IO/FileHelpers.h
+++ b/cpp/Platform.IO/FileHelpers.h
@@ -69,11 +69,11 @@
             }
         }
 
-        public: static void DeleteAll(std::string directory) { DeleteAll(directory, "*"); }
+        public: static void DeleteFiles(std::string directory) { DeleteFiles(directory, "*"); }
 
-        public: static void DeleteAll(std::string directory, std::string searchPattern) { DeleteAll(directory, searchPattern, SearchOption.TopDirectoryOnly); }
+        public: static void DeleteFiles(std::string directory, std::string searchPattern) { DeleteFiles(directory, searchPattern, SearchOption.TopDirectoryOnly); }
 
-        public: static void DeleteAll(std::string directory, std::string searchPattern, SearchOption searchOption)
+        public: static void DeleteFiles(std::string directory, std::string searchPattern, SearchOption searchOption)
         {
             foreach (auto file in Directory.EnumerateFiles(directory, searchPattern, searchOption))
             {

--- a/csharp/Platform.IO.Tests/FileHelpersTests.cs
+++ b/csharp/Platform.IO.Tests/FileHelpersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Xunit;
 
@@ -14,6 +15,37 @@ namespace Platform.IO.Tests
             var readValue = FileHelpers.ReadFirstOrDefault<ulong>(temporaryFile);
             Assert.Equal(readValue, originalValue);
             File.Delete(temporaryFile);
+        }
+
+        [Fact]
+        public void DeleteFilesTest()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            
+            var testFile1 = Path.Combine(tempDir, "test1.txt");
+            var testFile2 = Path.Combine(tempDir, "test2.txt");
+            var testFile3 = Path.Combine(tempDir, "test3.log");
+            
+            File.WriteAllText(testFile1, "test content");
+            File.WriteAllText(testFile2, "test content");
+            File.WriteAllText(testFile3, "test content");
+            
+            Assert.True(File.Exists(testFile1));
+            Assert.True(File.Exists(testFile2));
+            Assert.True(File.Exists(testFile3));
+            
+            FileHelpers.DeleteFiles(tempDir, "*.txt");
+            
+            Assert.False(File.Exists(testFile1));
+            Assert.False(File.Exists(testFile2));
+            Assert.True(File.Exists(testFile3));
+            
+            FileHelpers.DeleteFiles(tempDir);
+            
+            Assert.False(File.Exists(testFile3));
+            
+            Directory.Delete(tempDir);
         }
     }
 }

--- a/csharp/Platform.IO/FileHelpers.cs
+++ b/csharp/Platform.IO/FileHelpers.cs
@@ -207,7 +207,7 @@ namespace Platform.IO
         /// <para>Путь к директории для очистки.</para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteAll(string directory) => DeleteAll(directory, "*");
+        public static void DeleteFiles(string directory) => DeleteFiles(directory, "*");
 
         /// <summary>
         /// <para>Removes files from the directory at the path <paramref name="directory"/> according to the <paramref name="searchPattern"/>.</para>
@@ -222,7 +222,7 @@ namespace Platform.IO
         /// <para>Шаблон поиска для удаляемых файлов в директории находящейся по пути <paramref name="directory"/>.</para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteAll(string directory, string searchPattern) => DeleteAll(directory, searchPattern, SearchOption.TopDirectoryOnly);
+        public static void DeleteFiles(string directory, string searchPattern) => DeleteFiles(directory, searchPattern, SearchOption.TopDirectoryOnly);
 
         /// <summary>
         /// <para>Removes files from the directory at the path <paramref name="directory"/> according to the <paramref name="searchPattern"/> and the <paramref name="searchOption"/>.</para>
@@ -241,7 +241,7 @@ namespace Platform.IO
         /// <para>Значение <see cref="SearchOption"/> определяющее искать ли только в текущей директории находящейся по пути <paramref name="directory"/>, или также во всех субдиректориях.</para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteAll(string directory, string searchPattern, SearchOption searchOption)
+        public static void DeleteFiles(string directory, string searchPattern, SearchOption searchOption)
         {
             foreach (var file in Directory.EnumerateFiles(directory, searchPattern, searchOption))
             {


### PR DESCRIPTION
## Summary

Renamed the `DeleteAll` method in `FileHelpers` to `DeleteFiles` as requested in issue #53.

- Renamed `DeleteAll` method to `DeleteFiles` in both C# (`csharp/Platform.IO/FileHelpers.cs`) and C++ (`cpp/Platform.IO/FileHelpers.h`) implementations
- Updated all three overloads of the method:
  - `DeleteFiles(string directory)` - defaults to "*" pattern
  - `DeleteFiles(string directory, string searchPattern)` - defaults to TopDirectoryOnly
  - `DeleteFiles(string directory, string searchPattern, SearchOption searchOption)` - full control
- Added comprehensive test coverage for the renamed method in `FileHelpersTests.cs`
- Verified functionality with both pattern-specific deletion and wildcard behavior

## Test plan

- [x] All existing tests pass
- [x] New test `DeleteFilesTest` validates:
  - Pattern-specific file deletion (*.txt files only)
  - Wildcard deletion (all remaining files)  
  - Proper cleanup and directory handling
- [x] Build completes successfully for entire solution

The method name `DeleteFiles` was chosen over `DeleteMany` as it more clearly describes the method's purpose - specifically deleting files from directories based on search patterns.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #53