### PR TITLE
Rename directory parameter to path in DeleteAll methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/IO/issues/52
+Your prepared branch: issue-52-e758ca64
+Your prepared working directory: /tmp/gh-issue-solver-1757775929405
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/IO/issues/52
-Your prepared branch: issue-52-e758ca64
-Your prepared working directory: /tmp/gh-issue-solver-1757775929405
-
-Proceed.

--- a/cpp/Platform.IO/FileHelpers.h
+++ b/cpp/Platform.IO/FileHelpers.h
@@ -69,13 +69,13 @@
             }
         }
 
-        public: static void DeleteAll(std::string directory) { DeleteAll(directory, "*"); }
+        public: static void DeleteAll(std::string path) { DeleteAll(path, "*"); }
 
-        public: static void DeleteAll(std::string directory, std::string searchPattern) { DeleteAll(directory, searchPattern, SearchOption.TopDirectoryOnly); }
+        public: static void DeleteAll(std::string path, std::string searchPattern) { DeleteAll(path, searchPattern, SearchOption.TopDirectoryOnly); }
 
-        public: static void DeleteAll(std::string directory, std::string searchPattern, SearchOption searchOption)
+        public: static void DeleteAll(std::string path, std::string searchPattern, SearchOption searchOption)
         {
-            foreach (auto file in Directory.EnumerateFiles(directory, searchPattern, searchOption))
+            foreach (auto file in Directory.EnumerateFiles(path, searchPattern, searchOption))
             {
                 File.Delete(file);
             }

--- a/csharp/Platform.IO/FileHelpers.cs
+++ b/csharp/Platform.IO/FileHelpers.cs
@@ -199,51 +199,51 @@ namespace Platform.IO
         }
 
         /// <summary>
-        /// <para>Removes all files from the directory at the path <paramref name="directory"/>.</para>
-        /// <para>Удаляет все файлы из директории находящейся по пути <paramref name="directory"/>.</para>
+        /// <para>Removes all files from the directory at the path <paramref name="path"/>.</para>
+        /// <para>Удаляет все файлы из директории находящейся по пути <paramref name="path"/>.</para>
         /// </summary>
-        /// <param name="directory">
+        /// <param name="path">
         /// <para>The path to the directory to be cleaned.</para>
         /// <para>Путь к директории для очистки.</para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteAll(string directory) => DeleteAll(directory, "*");
+        public static void DeleteAll(string path) => DeleteAll(path, "*");
 
         /// <summary>
-        /// <para>Removes files from the directory at the path <paramref name="directory"/> according to the <paramref name="searchPattern"/>.</para>
-        /// <para>Удаляет файлы из директории находящейся по пути <paramref name="directory"/> в соотвествии с <paramref name="searchPattern"/>.</para>
+        /// <para>Removes files from the directory at the path <paramref name="path"/>.</para>
+        /// <para>Удаляет файлы из директории находящейся по пути <paramref name="path"/>.</para>
         /// </summary>
-        /// <param name="directory">
+        /// <param name="path">
         /// <para>The path to the directory to be cleaned.</para>
         /// <para>Путь к директории для очистки.</para>
         /// </param>
         /// <param name="searchPattern">
-        /// <para>The search pattern for files to be deleted in the directory at the path <paramref name="directory"/>.</para>
-        /// <para>Шаблон поиска для удаляемых файлов в директории находящейся по пути <paramref name="directory"/>.</para>
+        /// <para>The search pattern for files to be deleted in the directory at the path <paramref name="path"/>.</para>
+        /// <para>Шаблон поиска для удаляемых файлов в директории находящейся по пути <paramref name="path"/>.</para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteAll(string directory, string searchPattern) => DeleteAll(directory, searchPattern, SearchOption.TopDirectoryOnly);
+        public static void DeleteAll(string path, string searchPattern) => DeleteAll(path, searchPattern, SearchOption.TopDirectoryOnly);
 
         /// <summary>
-        /// <para>Removes files from the directory at the path <paramref name="directory"/> according to the <paramref name="searchPattern"/> and the <paramref name="searchOption"/>.</para>
-        /// <para>Удаляет файлы из директории находящейся по пути <paramref name="directory"/> в соотвествии с <paramref name="searchPattern"/> и <paramref name="searchOption"/>.</para>
+        /// <para>Removes files from the directory at the path <paramref name="path"/>.</para>
+        /// <para>Удаляет файлы из директории находящейся по пути <paramref name="path"/>.</para>
         /// </summary>
-        /// <param name="directory">
+        /// <param name="path">
         /// <para>The path to the directory to be cleaned.</para>
         /// <para>Путь к директории для очистки.</para>
         /// </param>
         /// <param name="searchPattern">
-        /// <para>The search pattern for files to be deleted in the directory at the path <paramref name="directory"/>.</para>
-        /// <para>Шаблон поиска для удаляемых файлов в директории находящейся по пути <paramref name="directory"/> .</para>
+        /// <para>The search pattern for files to be deleted in the directory at the path <paramref name="path"/>.</para>
+        /// <para>Шаблон поиска для удаляемых файлов в директории находящейся по пути <paramref name="path"/>.</para>
         /// </param>
         /// <param name="searchOption">
-        /// <para>The <see cref="SearchOption"/> value that determines whether to search only in the current the directory at the path <paramref name="directory"/>, or also in all subdirectories.</para>
-        /// <para>Значение <see cref="SearchOption"/> определяющее искать ли только в текущей директории находящейся по пути <paramref name="directory"/>, или также во всех субдиректориях.</para>
+        /// <para>The <see cref="SearchOption"/> value that determines whether to search only in the current directory at the path <paramref name="path"/>, or also in all subdirectories.</para>
+        /// <para>Значение <see cref="SearchOption"/> определяющее искать ли только в текущей директории находящейся по пути <paramref name="path"/>, или также во всех субдиректориях.</para>
         /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void DeleteAll(string directory, string searchPattern, SearchOption searchOption)
+        public static void DeleteAll(string path, string searchPattern, SearchOption searchOption)
         {
-            foreach (var file in Directory.EnumerateFiles(directory, searchPattern, searchOption))
+            foreach (var file in Directory.EnumerateFiles(path, searchPattern, searchOption))
             {
                 File.Delete(file);
             }


### PR DESCRIPTION
## Summary
- Rename 'directory' parameter to 'path' in all DeleteAll method overloads in both C# and C++ FileHelpers 
- Update XML documentation to reflect parameter name changes
- Simplified documentation comments as suggested in the issue

## Changes Made
- **C# FileHelpers.cs**: Renamed `directory` parameter to `path` in three DeleteAll method overloads
- **C++ FileHelpers.h**: Updated corresponding C++ method signatures to use `path` parameter
- **Documentation**: Updated all XML documentation comments to reference the new parameter name

## Test Plan
- [x] Build succeeded without errors  
- [x] All existing tests pass
- [x] Parameter naming now aligns with .NET Directory.EnumerateFiles convention

Fixes #52

🤖 Generated with [Claude Code](https://claude.ai/code)