### PR TITLE
Fix OrDefault methods to return default values instead of throwing exceptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/IO/issues/51
+Your prepared branch: issue-51-14b9cbf4
+Your prepared working directory: /tmp/gh-issue-solver-1757776650456
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/IO/issues/51
-Your prepared branch: issue-51-14b9cbf4
-Your prepared working directory: /tmp/gh-issue-solver-1757776650456
-
-Proceed.

--- a/csharp/Platform.IO.Tests/FileHelpersTests.cs
+++ b/csharp/Platform.IO.Tests/FileHelpersTests.cs
@@ -15,5 +15,33 @@ namespace Platform.IO.Tests
             Assert.Equal(readValue, originalValue);
             File.Delete(temporaryFile);
         }
+
+        [Fact]
+        public void ReadFirstOrDefaultShouldReturnDefaultForMisalignedFile()
+        {
+            var temporaryFile = Path.GetTempFileName();
+            // Write 5 bytes to create a file that's not aligned to ulong (8 bytes)
+            File.WriteAllBytes(temporaryFile, new byte[] { 1, 2, 3, 4, 5 });
+            
+            // This should return default(ulong) = 0, not throw an exception
+            var result = FileHelpers.ReadFirstOrDefault<ulong>(temporaryFile);
+            Assert.Equal(0UL, result);
+            
+            File.Delete(temporaryFile);
+        }
+
+        [Fact]
+        public void ReadLastOrDefaultShouldReturnDefaultForMisalignedFile()
+        {
+            var temporaryFile = Path.GetTempFileName();
+            // Write 5 bytes to create a file that's not aligned to ulong (8 bytes)
+            File.WriteAllBytes(temporaryFile, new byte[] { 1, 2, 3, 4, 5 });
+            
+            // This should return default(ulong) = 0, not throw an exception
+            var result = FileHelpers.ReadLastOrDefault<ulong>(temporaryFile);
+            Assert.Equal(0UL, result);
+            
+            File.Delete(temporaryFile);
+        }
     }
 }

--- a/csharp/Platform.IO/FileHelpers.cs
+++ b/csharp/Platform.IO/FileHelpers.cs
@@ -85,7 +85,7 @@ namespace Platform.IO
             var fileSize = GetSize(path);
             if (fileSize % elementSize != 0)
             {
-                throw new InvalidOperationException($"File is not aligned to elements with size {elementSize}.");
+                return null;
             }
             return fileSize > 0 ? File.OpenRead(path) : null;
         }


### PR DESCRIPTION
## Summary
- Fixed `GetValidFileStreamOrDefault` method in `FileHelpers.cs` to return `null` instead of throwing `InvalidOperationException` when file size is not aligned to element size
- This ensures `ReadFirstOrDefault<T>` and `ReadLastOrDefault<T>` methods follow the OrDefault convention of returning default values in unexpected cases
- Added comprehensive tests to verify correct behavior for misaligned files

## Problem
The issue was in the `GetValidFileStreamOrDefault` method at lines 86-89, where an `InvalidOperationException` was thrown when the file size was not aligned to the element size. This violated the OrDefault convention where methods ending with `OrDefault` should return default values instead of throwing exceptions.

## Solution  
Changed the exception-throwing code to return `null`, which causes the calling OrDefault methods to return their default values as expected.

## Test Plan
- [x] Existing tests continue to pass
- [x] Added `ReadFirstOrDefaultShouldReturnDefaultForMisalignedFile` test
- [x] Added `ReadLastOrDefaultShouldReturnDefaultForMisalignedFile` test
- [x] All tests pass successfully
- [x] Project builds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #51