### PR TITLE
refactor: rename UsedFilesListLock to UsedFilesListLockObject

### DIFF
--- a/cpp/Platform.IO/TemporaryFiles.h
+++ b/cpp/Platform.IO/TemporaryFiles.h
@@ -3,12 +3,12 @@
     class TemporaryFiles
     {
         private: inline static std::string UserFilesListFileNamePrefix = ".used-temporary-files.txt";
-        private: inline static const void *UsedFilesListLock = new();
+        private: inline static const void *UsedFilesListLockObject = new();
         private: inline static const std::string UsedFilesListFilename = Assembly.GetExecutingAssembly().Location + UserFilesListFileNamePrefix;
 
         private: static void AddToUsedFilesList(std::string filename)
         {
-            lock (UsedFilesListLock)
+            lock (UsedFilesListLockObject)
             {
                 FileHelpers.AppendLine(UsedFilesListFilename, filename);
             }
@@ -23,7 +23,7 @@
 
         public: static void DeleteAllPreviouslyUsed()
         {
-            lock (UsedFilesListLock)
+            lock (UsedFilesListLockObject)
             {
                 auto listFilename = UsedFilesListFilename;
                 if (File.Exists(listFilename))

--- a/csharp/Platform.IO/TemporaryFiles.cs
+++ b/csharp/Platform.IO/TemporaryFiles.cs
@@ -11,12 +11,12 @@ namespace Platform.IO
     public class TemporaryFiles
     {
         private const string UserFilesListFileNamePrefix = ".used-temporary-files.txt";
-        private static readonly object UsedFilesListLock = new();
+        private static readonly object UsedFilesListLockObject = new();
         private static readonly string UsedFilesListFilename = Assembly.GetExecutingAssembly().Location + UserFilesListFileNamePrefix;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void AddToUsedFilesList(string filename)
         {
-            lock (UsedFilesListLock)
+            lock (UsedFilesListLockObject)
             {
                 FileHelpers.AppendLine(UsedFilesListFilename, filename);
             }
@@ -45,7 +45,7 @@ namespace Platform.IO
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void DeleteAllPreviouslyUsed()
         {
-            lock (UsedFilesListLock)
+            lock (UsedFilesListLockObject)
             {
                 var listFilename = UsedFilesListFilename;
                 if (File.Exists(listFilename))


### PR DESCRIPTION
Renames the static lock object in TemporaryFiles (C# and C++) from UsedFilesListLock to UsedFilesListLockObject for clarity and consistency.

Fixes #83