### PR TITLE
docs: fix Truncates typo in FileHelpers.Truncate XML comment

### DIFF
--- a/csharp/Platform.IO/FileHelpers.cs
+++ b/csharp/Platform.IO/FileHelpers.cs
@@ -250,7 +250,7 @@ namespace Platform.IO
         }
 
         /// <summary>
-        /// <para>Trincates the file at the <paramref name="path"/>.</para>
+        /// <para>Truncates the file at the <paramref name="path"/>.</para>
         /// <para>Очищает содержимое файла по пути <paramref name="path"/>.</para>
         /// </summary>
         /// <param name="path">


### PR DESCRIPTION
Corrects the XML documentation spelling for FileHelpers.Truncate (Trincates → Truncates).